### PR TITLE
Using docker.io as registry for java images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
                                 <tags>
                                     <tag>latest</tag>
                                 </tags>
-                                <from>java:8</from>
+                                <from>docker.io/java:8</from>
                                 <assembly>
                                     <inline>
                                         <includeBaseDirectory>false</includeBaseDirectory>   


### PR DESCRIPTION
Without this, it tries to get the `java:8` from the configured registry - which does not have it, in case of `172.30.1.1:5000`