### PR TITLE
Updates to versioning, parent and GAV for processors

### DIFF
--- a/amqp/receiver/pom.xml
+++ b/amqp/receiver/pom.xml
@@ -20,8 +20,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.streamzi.cloudevent-flow</groupId>
-        <artifactId>operations</artifactId>
+        <groupId>io.streamzi.processors</groupId>
+        <artifactId>parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/amqp/sender/pom.xml
+++ b/amqp/sender/pom.xml
@@ -20,8 +20,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.streamzi.cloudevent-flow</groupId>
-        <artifactId>operations</artifactId>
+        <groupId>io.streamzi.processors</groupId>
+        <artifactId>parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/log-data/pom.xml
+++ b/log-data/pom.xml
@@ -2,8 +2,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.streamzi.cloudevent-flow</groupId>
-        <artifactId>operations</artifactId>
+        <groupId>io.streamzi.processors</groupId>
+        <artifactId>parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <groupId>io.streamzi</groupId>
-        <artifactId>cloudevent-flow</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>27</version>
     </parent>
 
-    <groupId>io.streamzi.cloudevent-flow</groupId>
-    <artifactId>operations</artifactId>
+    <groupId>io.streamzi.processors</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
     <packaging>pom</packaging>
     <name>cloudevent-flow-${project.artifactId}</name>
 
@@ -24,16 +27,19 @@
         <dependency>
             <groupId>io.streamzi.cloudevent-flow</groupId>
             <artifactId>model</artifactId>
-            <version>${project.version}</version>
+            <version>${flow-manager.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.streamzi.cloudevent-flow</groupId>
             <artifactId>container</artifactId>
-            <version>${project.version}</version>
+            <version>${flow-manager.version}</version>
         </dependency>
     </dependencies>
 
+    <properties>
+        <flow-manager.version>0.0.1</flow-manager.version>
+    </properties>
 
     <build>
         <pluginManagement>

--- a/random-data/pom.xml
+++ b/random-data/pom.xml
@@ -2,8 +2,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.streamzi.cloudevent-flow</groupId>
-        <artifactId>operations</artifactId>
+        <groupId>io.streamzi.processors</groupId>
+        <artifactId>parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>


### PR DESCRIPTION
fixing versioning and GAV for the processors - so they are now independent from the actual flow, and have their own artifact ID 