### PR TITLE
Adding dmp-push profile

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -8,15 +8,8 @@ else
     echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin docker.io
 
 ## Push the Java images, created in the maven build;
-    docker push docker.io/streamziprocessors/cef-ops-log-data:latest
 
-    docker push docker.io/streamziprocessors/cef-ops-filter-data:latest
-
-    docker push docker.io/streamziprocessors/cef-ops-random-data:latest
-
-    docker push docker.io/streamziprocessors/cef-ops-receiver:latest
-
-    docker push docker.io/streamziprocessors/cef-ops-sender:latest
+    mvn -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD clean install
 
 ## Build and Push the Node image;
     docker build -t docker.io/streamziprocessors/cef-ops-node-filter-event-data:latest nodejs/filter-events

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,6 @@
                                 </build>
                             </image>
                         </images>
-                        <skip>true</skip>
                     </configuration>
 
                     <executions>
@@ -116,7 +115,6 @@
                             </goals>
                         </execution>
 
-
                     </executions>
                 </plugin>
 
@@ -124,6 +122,40 @@
         </pluginManagement>
 
     </build>
+
+    <profiles>
+        <profile>
+            <id>Travis-non-pr-build</id>
+            <activation>
+                <property>
+                    <name>env.TRAVIS_PULL_REQUEST</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <inherited>true</inherited>
+                            <groupId>io.fabric8</groupId>
+                            <artifactId>docker-maven-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <phase>package</phase>
+                                    <id>build-push</id>
+                                    <goals>
+                                        <goal>build</goal>
+                                        <goal>push</goal>
+                                    </goals>
+                                </execution>
+
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 
     <repositories>
         <repository>


### PR DESCRIPTION
moving `docker push` to profile, activate on normal travis builds, and leveraging in build script the actual auth (via ENV VARS as system properties (`-D`)