### PR TITLE
Reflecting newly pushed java image names

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -12,7 +12,7 @@ else
     mvn -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD clean install -Pdh
 
 ## Build and Push the Node image;
-    docker build -t docker.io/streamziprocessors/cef-ops-node-filter-event-data:latest nodejs/filter-events
-    docker push docker.io/streamziprocessors/cef-ops-node-filter-event-data:latest
+    docker build -t docker.io/streamziprocessors/node-data-processor:latest nodejs/filter-events
+    docker push docker.io/streamziprocessors/node-data-processor:latest
 
 fi

--- a/amqp/receiver/src/main/resources/amqp-receiver-cr.yml
+++ b/amqp/receiver/src/main/resources/amqp-receiver-cr.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   displayName: "AMQP Receiver"
   description: "Logs AMQP messages"
-  imageName: "streamziprocessors/cef-ops-receiver"
+  imageName: "streamziprocessors/amqp-receiver"
   inputs:
     - "input-data"
   outputs:

--- a/amqp/sender/src/main/resources/amqp-sender-cr.yml
+++ b/amqp/sender/src/main/resources/amqp-sender-cr.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   displayName: "AMQP Sender"
   description: "Sends random doubles as AMQP messages"
-  imageName: "streamziprocessors/cef-ops-sender"
+  imageName: "streamziprocessors/amqp-sender"
   inputs:
   outputs:
     - "output-data"

--- a/data-processor/src/main/resources/processor-cr.yml
+++ b/data-processor/src/main/resources/processor-cr.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   displayName: "Filter"
   description: "Filters data based on value"
-  imageName: "streamziprocessors/cef-ops-filter-data"
+  imageName: "streamziprocessors/data-processor"
   inputs:
     - "input-data"
   outputs:

--- a/data-sink/src/main/resources/sink-cr.yml
+++ b/data-sink/src/main/resources/sink-cr.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   displayName: "Log Data"
   description: "Prints the data received to console"
-  imageName: "streamziprocessors/cef-ops-log-data"
+  imageName: "streamziprocessors/data-sink"
   inputs:
     - "input-data"
   outputs:

--- a/data-source/src/main/resources/source-cr.yml
+++ b/data-source/src/main/resources/source-cr.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   displayName: "Random Source"
   description: "Generates random doubles 0 < n < 1"
-  imageName: "streamziprocessors/cef-ops-random-data"
+  imageName: "streamziprocessors/data-source"
   inputs:
   outputs:
     - "output-data"

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,6 @@
 
 echo "Installing event-flow samples"
 
-oc create -f https://raw.githubusercontent.com/project-streamzi/event-flow-operation-samples/master/random-data/src/main/resources/random-data-cr.yml
-oc create -f https://raw.githubusercontent.com/project-streamzi/event-flow-operation-samples/master/filter-data/src/main/resources/filter-data-cr.yml
-oc create -f https://raw.githubusercontent.com/project-streamzi/event-flow-operation-samples/master/log-data/src/main/resources/log-data-cr.yml
+oc create -f https://raw.githubusercontent.com/project-streamzi/event-flow-operation-samples/master/data-source/src/main/resources/source-cr.yml
+oc create -f https://raw.githubusercontent.com/project-streamzi/event-flow-operation-samples/master/data-processor/src/main/resources/processor-cr.yml
+oc create -f https://raw.githubusercontent.com/project-streamzi/event-flow-operation-samples/master/data-sink/src/main/resources/sink-cr.yml

--- a/nodejs/filter-events/build.sh
+++ b/nodejs/filter-events/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo 'Building Filter Events Processor'
-docker build -t docker.io/streamziprocessors/cef-ops-node-filter-event-data .
-docker tag docker.io/streamziprocessors/cef-ops-node-filter-event-data:latest docker.io/streamziprocessors/cef-ops-node-filter-event-data:latest
+docker build -t docker.io/streamziprocessors/node-data-processor .
+docker tag docker.io/streamziprocessors/node-data-processor:latest docker.io/streamziprocessors/node-data-processor:latest

--- a/nodejs/filter-events/filter-data-cr.yml
+++ b/nodejs/filter-events/filter-data-cr.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   displayName: "Filter Events"
   description: "Applies a simple filter to a stream of events"
-  imageName: "streamziprocessors/cef-ops-node-filter-event-data"
+  imageName: "streamziprocessors/node-data-processor"
   inputs:
   - "input-data"
   outputs:


### PR DESCRIPTION
The java images got new names, during the `GAV` refactoring.

and they are already pushed to `dh` that way.



